### PR TITLE
shio: Bump x265 from 0dfbe6dee33263d2bc8a12a06b7e3925f276560d to d1940b4e003cd5b8edbab8d20e4e39d143726d60

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -921,8 +921,8 @@ RUN \
 # bump: x265 /X265_VERSION=([[:xdigit:]]+)/ gitrefs:https://bitbucket.org/multicoreware/x265_git.git|re:#^refs/heads/master$#|@commit
 # bump: x265 after cd build && ./hashupdate Dockerfile X265 $LATEST
 # bump: x265 link "Source diff $CURRENT..$LATEST" https://bitbucket.org/multicoreware/x265_git/branches/compare/$LATEST..$CURRENT#diff
-ARG X265_VERSION=0dfbe6dee33263d2bc8a12a06b7e3925f276560d
-ARG X265_SHA256=3acef49f87967e9a257498c13a2d69c5f6d14472eebe4918eb85a5ebbe2f990e
+ARG X265_VERSION=d1940b4e003cd5b8edbab8d20e4e39d143726d60
+ARG X265_SHA256=f5e3783d831a150a8a65d2492171d5f91038fd2148dd8a3e481b439ad49ffb54
 ARG X265_URL="https://bitbucket.org/multicoreware/x265_git/get/$X265_VERSION.tar.bz2"
 # CMAKEFLAGS issue
 # https://bitbucket.org/multicoreware/x265_git/issues/620/support-passing-cmake-flags-to-multilibsh


### PR DESCRIPTION
[Source diff 0dfbe6dee33263d2bc8a12a06b7e3925f276560d..d1940b4e003cd5b8edbab8d20e4e39d143726d60](https://bitbucket.org/multicoreware/x265_git/branches/compare/d1940b4e003cd5b8edbab8d20e4e39d143726d60..0dfbe6dee33263d2bc8a12a06b7e3925f276560d#diff)  
