### PR TITLE
shio: Bump x265 from d1940b4e003cd5b8edbab8d20e4e39d143726d60 to cdf897bfba098666e673a64a96fda4c057318699

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -921,8 +921,8 @@ RUN \
 # bump: x265 /X265_VERSION=([[:xdigit:]]+)/ gitrefs:https://bitbucket.org/multicoreware/x265_git.git|re:#^refs/heads/master$#|@commit
 # bump: x265 after cd build && ./hashupdate Dockerfile X265 $LATEST
 # bump: x265 link "Source diff $CURRENT..$LATEST" https://bitbucket.org/multicoreware/x265_git/branches/compare/$LATEST..$CURRENT#diff
-ARG X265_VERSION=d1940b4e003cd5b8edbab8d20e4e39d143726d60
-ARG X265_SHA256=f5e3783d831a150a8a65d2492171d5f91038fd2148dd8a3e481b439ad49ffb54
+ARG X265_VERSION=cdf897bfba098666e673a64a96fda4c057318699
+ARG X265_SHA256=b3e04b434cdefff877b5830af8a5bd59980de220c08c5e9cafa2ff8ce71d45b4
 ARG X265_URL="https://bitbucket.org/multicoreware/x265_git/get/$X265_VERSION.tar.bz2"
 # CMAKEFLAGS issue
 # https://bitbucket.org/multicoreware/x265_git/issues/620/support-passing-cmake-flags-to-multilibsh


### PR DESCRIPTION
[Source diff d1940b4e003cd5b8edbab8d20e4e39d143726d60..cdf897bfba098666e673a64a96fda4c057318699](https://bitbucket.org/multicoreware/x265_git/branches/compare/cdf897bfba098666e673a64a96fda4c057318699..d1940b4e003cd5b8edbab8d20e4e39d143726d60#diff)  
