### PR TITLE
shio: Bump x265 from cdf897bfba098666e673a64a96fda4c057318699 to 1a826a1d2b19c74145c70c781364f0cd926862e1

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -921,8 +921,8 @@ RUN \
 # bump: x265 /X265_VERSION=([[:xdigit:]]+)/ gitrefs:https://bitbucket.org/multicoreware/x265_git.git|re:#^refs/heads/master$#|@commit
 # bump: x265 after cd build && ./hashupdate Dockerfile X265 $LATEST
 # bump: x265 link "Source diff $CURRENT..$LATEST" https://bitbucket.org/multicoreware/x265_git/branches/compare/$LATEST..$CURRENT#diff
-ARG X265_VERSION=cdf897bfba098666e673a64a96fda4c057318699
-ARG X265_SHA256=b3e04b434cdefff877b5830af8a5bd59980de220c08c5e9cafa2ff8ce71d45b4
+ARG X265_VERSION=1a826a1d2b19c74145c70c781364f0cd926862e1
+ARG X265_SHA256=b80aca10db35b1db2c5b90c07ed231f16c497d92329bdfc36d442c32b48f8e9c
 ARG X265_URL="https://bitbucket.org/multicoreware/x265_git/get/$X265_VERSION.tar.bz2"
 # CMAKEFLAGS issue
 # https://bitbucket.org/multicoreware/x265_git/issues/620/support-passing-cmake-flags-to-multilibsh


### PR DESCRIPTION
[Source diff cdf897bfba098666e673a64a96fda4c057318699..1a826a1d2b19c74145c70c781364f0cd926862e1](https://bitbucket.org/multicoreware/x265_git/branches/compare/1a826a1d2b19c74145c70c781364f0cd926862e1..cdf897bfba098666e673a64a96fda4c057318699#diff)  
