### PR TITLE
shio: Bump x265 from cdf897bfba098666e673a64a96fda4c057318699 to a009ec07721b1e7fcf5289619a3cd5dd6b67a546

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -921,8 +921,8 @@ RUN \
 # bump: x265 /X265_VERSION=([[:xdigit:]]+)/ gitrefs:https://bitbucket.org/multicoreware/x265_git.git|re:#^refs/heads/master$#|@commit
 # bump: x265 after cd build && ./hashupdate Dockerfile X265 $LATEST
 # bump: x265 link "Source diff $CURRENT..$LATEST" https://bitbucket.org/multicoreware/x265_git/branches/compare/$LATEST..$CURRENT#diff
-ARG X265_VERSION=cdf897bfba098666e673a64a96fda4c057318699
-ARG X265_SHA256=b3e04b434cdefff877b5830af8a5bd59980de220c08c5e9cafa2ff8ce71d45b4
+ARG X265_VERSION=a009ec07721b1e7fcf5289619a3cd5dd6b67a546
+ARG X265_SHA256=833cc28f7fb472e770f06f553ea351b3c190e171e364456f0cd0106c4e5f8ab0
 ARG X265_URL="https://bitbucket.org/multicoreware/x265_git/get/$X265_VERSION.tar.bz2"
 # CMAKEFLAGS issue
 # https://bitbucket.org/multicoreware/x265_git/issues/620/support-passing-cmake-flags-to-multilibsh


### PR DESCRIPTION
[Source diff cdf897bfba098666e673a64a96fda4c057318699..a009ec07721b1e7fcf5289619a3cd5dd6b67a546](https://bitbucket.org/multicoreware/x265_git/branches/compare/a009ec07721b1e7fcf5289619a3cd5dd6b67a546..cdf897bfba098666e673a64a96fda4c057318699#diff)  
