### PR TITLE
shio: Bump x265 from a009ec07721b1e7fcf5289619a3cd5dd6b67a546 to 304f02f7aaa686fc4e2c77b1404d75ae8ab76b5b

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -921,8 +921,8 @@ RUN \
 # bump: x265 /X265_VERSION=([[:xdigit:]]+)/ gitrefs:https://bitbucket.org/multicoreware/x265_git.git|re:#^refs/heads/master$#|@commit
 # bump: x265 after cd build && ./hashupdate Dockerfile X265 $LATEST
 # bump: x265 link "Source diff $CURRENT..$LATEST" https://bitbucket.org/multicoreware/x265_git/branches/compare/$LATEST..$CURRENT#diff
-ARG X265_VERSION=a009ec07721b1e7fcf5289619a3cd5dd6b67a546
-ARG X265_SHA256=833cc28f7fb472e770f06f553ea351b3c190e171e364456f0cd0106c4e5f8ab0
+ARG X265_VERSION=304f02f7aaa686fc4e2c77b1404d75ae8ab76b5b
+ARG X265_SHA256=7fdf307bb14a3cc94a74e6261c8853259a94d1fa0d4454a815e27df4e621cf42
 ARG X265_URL="https://bitbucket.org/multicoreware/x265_git/get/$X265_VERSION.tar.bz2"
 # CMAKEFLAGS issue
 # https://bitbucket.org/multicoreware/x265_git/issues/620/support-passing-cmake-flags-to-multilibsh


### PR DESCRIPTION
[Source diff a009ec07721b1e7fcf5289619a3cd5dd6b67a546..304f02f7aaa686fc4e2c77b1404d75ae8ab76b5b](https://bitbucket.org/multicoreware/x265_git/branches/compare/304f02f7aaa686fc4e2c77b1404d75ae8ab76b5b..a009ec07721b1e7fcf5289619a3cd5dd6b67a546#diff)  
