### PR TITLE
shio: Bump x265 from a009ec07721b1e7fcf5289619a3cd5dd6b67a546 to 26d2bab0063cee453b7d8012e76539a7786c032f

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -921,8 +921,8 @@ RUN \
 # bump: x265 /X265_VERSION=([[:xdigit:]]+)/ gitrefs:https://bitbucket.org/multicoreware/x265_git.git|re:#^refs/heads/master$#|@commit
 # bump: x265 after cd build && ./hashupdate Dockerfile X265 $LATEST
 # bump: x265 link "Source diff $CURRENT..$LATEST" https://bitbucket.org/multicoreware/x265_git/branches/compare/$LATEST..$CURRENT#diff
-ARG X265_VERSION=a009ec07721b1e7fcf5289619a3cd5dd6b67a546
-ARG X265_SHA256=833cc28f7fb472e770f06f553ea351b3c190e171e364456f0cd0106c4e5f8ab0
+ARG X265_VERSION=26d2bab0063cee453b7d8012e76539a7786c032f
+ARG X265_SHA256=2233a23b3c45820d2e98285248d4306ad40cd31fd305d67e80823357fd994339
 ARG X265_URL="https://bitbucket.org/multicoreware/x265_git/get/$X265_VERSION.tar.bz2"
 # CMAKEFLAGS issue
 # https://bitbucket.org/multicoreware/x265_git/issues/620/support-passing-cmake-flags-to-multilibsh


### PR DESCRIPTION
[Source diff a009ec07721b1e7fcf5289619a3cd5dd6b67a546..26d2bab0063cee453b7d8012e76539a7786c032f](https://bitbucket.org/multicoreware/x265_git/branches/compare/26d2bab0063cee453b7d8012e76539a7786c032f..a009ec07721b1e7fcf5289619a3cd5dd6b67a546#diff)  
