### PR TITLE
shio: Bump svtav1 from 2.2.1 to 2.3.0

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -722,9 +722,9 @@ RUN \
 # bump: svtav1 /SVTAV1_VERSION=([\d.]+)/ https://gitlab.com/AOMediaCodec/SVT-AV1.git|*
 # bump: svtav1 after cd build && ./hashupdate Dockerfile SVTAV1 $LATEST
 # bump: svtav1 link "Release notes" https://gitlab.com/AOMediaCodec/SVT-AV1/-/releases/v$LATEST
-ARG SVTAV1_VERSION=2.2.1
+ARG SVTAV1_VERSION=2.3.0
 ARG SVTAV1_URL="https://gitlab.com/AOMediaCodec/SVT-AV1/-/archive/v$SVTAV1_VERSION/SVT-AV1-v$SVTAV1_VERSION.tar.bz2"
-ARG SVTAV1_SHA256=3fd002b88816506f84b6d624659be5cbadb4cdf5a11258a5cbc6bfc488c82d01
+ARG SVTAV1_SHA256=f65358499f572a47d6b076dda73681a8162b02c0b619a551bc2d62ead8ee719a
 RUN \
   wget $WGET_OPTS -O svtav1.tar.bz2 "$SVTAV1_URL" && \
   echo "$SVTAV1_SHA256  svtav1.tar.bz2" | sha256sum -c - && \


### PR DESCRIPTION
[Release notes](https://gitlab.com/AOMediaCodec/SVT-AV1/-/releases/v2.3.0)  
