### PR TITLE
shio: Bump x265 from 7b5332d9df9a26204861009a9d68f28a2898e3ea to 5203eb5256527216f89f85cf10094f3f788e6d0b

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -921,8 +921,8 @@ RUN \
 # bump: x265 /X265_VERSION=([[:xdigit:]]+)/ gitrefs:https://bitbucket.org/multicoreware/x265_git.git|re:#^refs/heads/master$#|@commit
 # bump: x265 after cd build && ./hashupdate Dockerfile X265 $LATEST
 # bump: x265 link "Source diff $CURRENT..$LATEST" https://bitbucket.org/multicoreware/x265_git/branches/compare/$LATEST..$CURRENT#diff
-ARG X265_VERSION=7b5332d9df9a26204861009a9d68f28a2898e3ea
-ARG X265_SHA256=d2f719ae301cd395c918250ea5717c9c19451107f0c29dc19052202db367da52
+ARG X265_VERSION=5203eb5256527216f89f85cf10094f3f788e6d0b
+ARG X265_SHA256=80742be85ee81d5ca90b3626f7cafb79a7224f92bf1451d190b0ccc320ea03c3
 ARG X265_URL="https://bitbucket.org/multicoreware/x265_git/get/$X265_VERSION.tar.bz2"
 # CMAKEFLAGS issue
 # https://bitbucket.org/multicoreware/x265_git/issues/620/support-passing-cmake-flags-to-multilibsh


### PR DESCRIPTION
[Source diff 7b5332d9df9a26204861009a9d68f28a2898e3ea..5203eb5256527216f89f85cf10094f3f788e6d0b](https://bitbucket.org/multicoreware/x265_git/branches/compare/5203eb5256527216f89f85cf10094f3f788e6d0b..7b5332d9df9a26204861009a9d68f28a2898e3ea#diff)  
