### PR TITLE
shio: Bump libgme from cb2c1ccc7563ed58321cc3b6b8507b9015192b80 to e5a910a55b03fe898111880e3e1c1c02e442956c

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -371,7 +371,7 @@ RUN \
 # bump: libgme after cd build && ./hashupdate Dockerfile LIBGME $LATEST
 # bump: libgme link "Source diff $CURRENT..$LATEST" https://github.com/libgme/game-music-emu/compare/$CURRENT..v$LATEST
 ARG LIBGME_URL="https://github.com/libgme/game-music-emu.git"
-ARG LIBGME_COMMIT=cb2c1ccc7563ed58321cc3b6b8507b9015192b80
+ARG LIBGME_COMMIT=e5a910a55b03fe898111880e3e1c1c02e442956c
 RUN \
   git clone "$LIBGME_URL" && \
   cd game-music-emu && git checkout --recurse-submodules $LIBGME_COMMIT && \


### PR DESCRIPTION
[Source diff cb2c1ccc7563ed58321cc3b6b8507b9015192b80..e5a910a55b03fe898111880e3e1c1c02e442956c](https://github.com/libgme/game-music-emu/compare/cb2c1ccc7563ed58321cc3b6b8507b9015192b80..ve5a910a55b03fe898111880e3e1c1c02e442956c)  
