### PR TITLE
shio: Bump pango from 1.55.0 to 1.56.1

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -192,9 +192,9 @@ RUN \
 # bump: pango /PANGO_VERSION=([\d.]+)/ https://github.com/GNOME/pango.git|/\d+\.\d+\.\d+/|*
 # bump: pango after cd build && ./hashupdate Dockerfile PANGO $LATEST
 # bump: pango link "NEWS" https://gitlab.gnome.org/GNOME/pango/-/blob/main/NEWS?ref_type=heads
-ARG PANGO_VERSION=1.55.0
-ARG PANGO_URL="https://download.gnome.org/sources/pango/1.55/pango-$PANGO_VERSION.tar.xz"
-ARG PANGO_SHA256=a2c17a8dc459a7267b8b167bb149d23ff473b6ff9d5972bee047807ee2220ccf
+ARG PANGO_VERSION=1.56.1
+ARG PANGO_URL="https://download.gnome.org/sources/pango/1.56/pango-$PANGO_VERSION.tar.xz"
+ARG PANGO_SHA256=426be66460c98b8378573e7f6b0b2ab450f6bb6d2ec7cecc33ae81178f246480
 # TODO: add -Dbuild-testsuite=false when in stable release
 # TODO: -Ddefault_library=both currently to not fail building tests
 RUN \


### PR DESCRIPTION
[NEWS](https://gitlab.gnome.org/GNOME/pango/-/blob/main/NEWS?ref_type=heads)  
