### PR TITLE
shio: Bump libgme from 903cf8d612411ff902efc22095680cd5276d6dcc to ddfc56ec9f741412495f9078535bb61f8f737e38

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -371,7 +371,7 @@ RUN \
 # bump: libgme after cd build && ./hashupdate Dockerfile LIBGME $LATEST
 # bump: libgme link "Source diff $CURRENT..$LATEST" https://github.com/libgme/game-music-emu/compare/$CURRENT..v$LATEST
 ARG LIBGME_URL="https://github.com/libgme/game-music-emu.git"
-ARG LIBGME_COMMIT=903cf8d612411ff902efc22095680cd5276d6dcc
+ARG LIBGME_COMMIT=ddfc56ec9f741412495f9078535bb61f8f737e38
 RUN \
   git clone "$LIBGME_URL" && \
   cd game-music-emu && git checkout --recurse-submodules $LIBGME_COMMIT && \


### PR DESCRIPTION
[Source diff 903cf8d612411ff902efc22095680cd5276d6dcc..ddfc56ec9f741412495f9078535bb61f8f737e38](https://github.com/libgme/game-music-emu/compare/903cf8d612411ff902efc22095680cd5276d6dcc..vddfc56ec9f741412495f9078535bb61f8f737e38)  
