### PR TITLE
shio: Bump libgme from 903cf8d612411ff902efc22095680cd5276d6dcc to a3d42050e564c17c55d211eceb27fe8726e7278d

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -371,7 +371,7 @@ RUN \
 # bump: libgme after cd build && ./hashupdate Dockerfile LIBGME $LATEST
 # bump: libgme link "Source diff $CURRENT..$LATEST" https://github.com/libgme/game-music-emu/compare/$CURRENT..v$LATEST
 ARG LIBGME_URL="https://github.com/libgme/game-music-emu.git"
-ARG LIBGME_COMMIT=903cf8d612411ff902efc22095680cd5276d6dcc
+ARG LIBGME_COMMIT=a3d42050e564c17c55d211eceb27fe8726e7278d
 RUN \
   git clone "$LIBGME_URL" && \
   cd game-music-emu && git checkout --recurse-submodules $LIBGME_COMMIT && \


### PR DESCRIPTION
[Source diff 903cf8d612411ff902efc22095680cd5276d6dcc..a3d42050e564c17c55d211eceb27fe8726e7278d](https://github.com/libgme/game-music-emu/compare/903cf8d612411ff902efc22095680cd5276d6dcc..va3d42050e564c17c55d211eceb27fe8726e7278d)  
