### PR TITLE
shio: Bump libgme from a3d42050e564c17c55d211eceb27fe8726e7278d to daaa7c67dcb21a08d984b2bfd3fc508d60c08bed

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -373,7 +373,7 @@ RUN \
 # bump: libgme after cd build && ./hashupdate Dockerfile LIBGME $LATEST
 # bump: libgme link "Source diff $CURRENT..$LATEST" https://github.com/libgme/game-music-emu/compare/$CURRENT..v$LATEST
 ARG LIBGME_URL="https://github.com/libgme/game-music-emu.git"
-ARG LIBGME_COMMIT=a3d42050e564c17c55d211eceb27fe8726e7278d
+ARG LIBGME_COMMIT=daaa7c67dcb21a08d984b2bfd3fc508d60c08bed
 RUN \
   git clone "$LIBGME_URL" && \
   cd game-music-emu && git checkout --recurse-submodules $LIBGME_COMMIT && \


### PR DESCRIPTION
[Source diff a3d42050e564c17c55d211eceb27fe8726e7278d..daaa7c67dcb21a08d984b2bfd3fc508d60c08bed](https://github.com/libgme/game-music-emu/compare/a3d42050e564c17c55d211eceb27fe8726e7278d..vdaaa7c67dcb21a08d984b2bfd3fc508d60c08bed)  
