### PR TITLE
shio: Bump pango from 1.56.1 to 1.56.2

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -194,9 +194,9 @@ RUN \
 # bump: pango /PANGO_VERSION=([\d.]+)/ https://github.com/GNOME/pango.git|/\d+\.\d+\.\d+/|*
 # bump: pango after cd build && ./hashupdate Dockerfile PANGO $LATEST
 # bump: pango link "NEWS" https://gitlab.gnome.org/GNOME/pango/-/blob/main/NEWS?ref_type=heads
-ARG PANGO_VERSION=1.56.1
+ARG PANGO_VERSION=1.56.2
 ARG PANGO_URL="https://download.gnome.org/sources/pango/1.56/pango-$PANGO_VERSION.tar.xz"
-ARG PANGO_SHA256=426be66460c98b8378573e7f6b0b2ab450f6bb6d2ec7cecc33ae81178f246480
+ARG PANGO_SHA256=03b7afd7ed730bef651155cbfb5320556b8ef92b0dc04abbb9784dcd4057afe7
 # TODO: add -Dbuild-testsuite=false when in stable release
 # TODO: -Ddefault_library=both currently to not fail building tests
 RUN \


### PR DESCRIPTION
[NEWS](https://gitlab.gnome.org/GNOME/pango/-/blob/main/NEWS?ref_type=heads)  
