### PR TITLE
shio: Bump theora from 1.1.1 to 1.2.0

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -762,13 +762,13 @@ RUN \
 # bump: theora after cd build && ./hashupdate Dockerfile THEORA $LATEST
 # bump: theora link "Release notes" https://github.com/xiph/theora/releases/tag/v$LATEST
 # bump: theora link "Source diff $CURRENT..$LATEST" https://github.com/xiph/theora/compare/v$CURRENT..v$LATEST
-ARG THEORA_VERSION=1.1.1
-ARG THEORA_URL="https://downloads.xiph.org/releases/theora/libtheora-$THEORA_VERSION.tar.bz2"
-ARG THEORA_SHA256=b6ae1ee2fa3d42ac489287d3ec34c5885730b1296f0801ae577a35193d3affbc
+ARG THEORA_VERSION=1.2.0
+ARG THEORA_URL="https://downloads.xiph.org/releases/theora/libtheora-$THEORA_VERSION.tar.gz"
+ARG THEORA_SHA256=279327339903b544c28a92aeada7d0dcfd0397b59c2f368cc698ac56f515906e
 RUN \
-  wget $WGET_OPTS -O libtheora.tar.bz2 "$THEORA_URL" && \
-  echo "$THEORA_SHA256  libtheora.tar.bz2" | sha256sum -c - && \
-  tar $TAR_OPTS libtheora.tar.bz2 && cd libtheora-* && \
+  wget $WGET_OPTS -O libtheora.tar.gz "$THEORA_URL" && \
+  echo "$THEORA_SHA256  libtheora.tar.gz" | sha256sum -c - && \
+  tar $TAR_OPTS libtheora.tar.gz && cd libtheora-* && \
   # --build=$(arch)-unknown-linux-gnu helps with guessing the correct build. For some reason,
   # build script can't guess the build type in arm64 (hardware and emulated) environment.
  ./configure \


### PR DESCRIPTION
[Release notes](https://github.com/xiph/theora/releases/tag/v1.2.0)  
[Source diff 1.1.1..1.2.0](https://github.com/xiph/theora/compare/v1.1.1..v1.2.0)  
