### PR TITLE
shio: Bump libgme from daaa7c67dcb21a08d984b2bfd3fc508d60c08bed to 9762cbcff3d2224ee0f8b8c41ec143e956ebad56

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -373,7 +373,7 @@ RUN \
 # bump: libgme after cd build && ./hashupdate Dockerfile LIBGME $LATEST
 # bump: libgme link "Source diff $CURRENT..$LATEST" https://github.com/libgme/game-music-emu/compare/$CURRENT..v$LATEST
 ARG LIBGME_URL="https://github.com/libgme/game-music-emu.git"
-ARG LIBGME_COMMIT=daaa7c67dcb21a08d984b2bfd3fc508d60c08bed
+ARG LIBGME_COMMIT=9762cbcff3d2224ee0f8b8c41ec143e956ebad56
 RUN \
   git clone "$LIBGME_URL" && \
   cd game-music-emu && git checkout --recurse-submodules $LIBGME_COMMIT && \


### PR DESCRIPTION
[Source diff daaa7c67dcb21a08d984b2bfd3fc508d60c08bed..9762cbcff3d2224ee0f8b8c41ec143e956ebad56](https://github.com/libgme/game-music-emu/compare/daaa7c67dcb21a08d984b2bfd3fc508d60c08bed..v9762cbcff3d2224ee0f8b8c41ec143e956ebad56)  
