### PR TITLE
shio: Bump harfbuzz from 11.2.0 to 11.2.1

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -158,9 +158,9 @@ RUN \
 # bump: harfbuzz /LIBHARFBUZZ_VERSION=([\d.]+)/ https://github.com/harfbuzz/harfbuzz.git|*
 # bump: harfbuzz after cd build && ./hashupdate Dockerfile LIBHARFBUZZ $LATEST
 # bump: harfbuzz link "NEWS" https://github.com/harfbuzz/harfbuzz/blob/main/NEWS
-ARG LIBHARFBUZZ_VERSION=11.2.0
+ARG LIBHARFBUZZ_VERSION=11.2.1
 ARG LIBHARFBUZZ_URL="https://github.com/harfbuzz/harfbuzz/releases/download/$LIBHARFBUZZ_VERSION/harfbuzz-$LIBHARFBUZZ_VERSION.tar.xz"
-ARG LIBHARFBUZZ_SHA256=50f7d0a208367e606dbf6eecc5cfbecc01a47be6ee837ae7aff2787e24b09b45
+ARG LIBHARFBUZZ_SHA256=093714c8548a285094685f0bdc999e202d666b59eeb3df2ff921ab68b8336a49
 RUN \
   wget $WGET_OPTS -O harfbuzz.tar.xz "$LIBHARFBUZZ_URL" && \
   echo "$LIBHARFBUZZ_SHA256  harfbuzz.tar.xz" | sha256sum --status -c - && \


### PR DESCRIPTION
[NEWS](https://github.com/harfbuzz/harfbuzz/blob/main/NEWS)  
