### PR TITLE
shio: Bump libwebp from 1.5.0 to 1.6.0

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -881,9 +881,9 @@ RUN \
 # bump: libwebp after cd build && ./hashupdate Dockerfile LIBWEBP $LATEST
 # bump: libwebp link "Release notes" https://github.com/webmproject/libwebp/releases/tag/v$LATEST
 # bump: libwebp link "Source diff $CURRENT..$LATEST" https://github.com/webmproject/libwebp/compare/v$CURRENT..v$LATEST
-ARG LIBWEBP_VERSION=1.5.0
+ARG LIBWEBP_VERSION=1.6.0
 ARG LIBWEBP_URL="https://github.com/webmproject/libwebp/archive/v$LIBWEBP_VERSION.tar.gz"
-ARG LIBWEBP_SHA256=668c9aba45565e24c27e17f7aaf7060a399f7f31dba6c97a044e1feacb930f37
+ARG LIBWEBP_SHA256=93a852c2b3efafee3723efd4636de855b46f9fe1efddd607e1f42f60fc8f2136
 RUN \
   wget $WGET_OPTS -O libwebp.tar.gz "$LIBWEBP_URL" && \
   echo "$LIBWEBP_SHA256  libwebp.tar.gz" | sha256sum -c - && \


### PR DESCRIPTION
[Release notes](https://github.com/webmproject/libwebp/releases/tag/v1.6.0)  
[Source diff 1.5.0..1.6.0](https://github.com/webmproject/libwebp/compare/v1.5.0..v1.6.0)  
