### PR TITLE
shio: Bump libgme from 9762cbcff3d2224ee0f8b8c41ec143e956ebad56 to 248ef2320195100d9796c99998ecc3832cf95639

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -375,7 +375,7 @@ RUN \
 # bump: libgme after cd build && ./hashupdate Dockerfile LIBGME $LATEST
 # bump: libgme link "Source diff $CURRENT..$LATEST" https://github.com/libgme/game-music-emu/compare/$CURRENT..v$LATEST
 ARG LIBGME_URL="https://github.com/libgme/game-music-emu.git"
-ARG LIBGME_COMMIT=9762cbcff3d2224ee0f8b8c41ec143e956ebad56
+ARG LIBGME_COMMIT=248ef2320195100d9796c99998ecc3832cf95639
 RUN \
   git clone "$LIBGME_URL" && \
   cd game-music-emu && git checkout --recurse-submodules $LIBGME_COMMIT && \


### PR DESCRIPTION
[Source diff 9762cbcff3d2224ee0f8b8c41ec143e956ebad56..248ef2320195100d9796c99998ecc3832cf95639](https://github.com/libgme/game-music-emu/compare/9762cbcff3d2224ee0f8b8c41ec143e956ebad56..v248ef2320195100d9796c99998ecc3832cf95639)  
