### PR TITLE
shio: Bump glib from 2.85.2 to 2.85.3

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -142,9 +142,9 @@ RUN sed -i 's/-lvmaf /-lvmaf -lstdc++ /' /usr/local/lib/pkgconfig/libvmaf.pc
 # bump: glib /GLIB_VERSION=([\d.]+)/ https://gitlab.gnome.org/GNOME/glib.git|^2
 # bump: glib after cd build && ./hashupdate Dockerfile GLIB $LATEST
 # bump: glib link "NEWS" https://gitlab.gnome.org/GNOME/glib/-/blob/main/NEWS?ref_type=heads
-ARG GLIB_VERSION=2.85.2
+ARG GLIB_VERSION=2.85.3
 ARG GLIB_URL="https://download.gnome.org/sources/glib/2.85/glib-$GLIB_VERSION.tar.xz"
-ARG GLIB_SHA256=833b97c0f0a1bfdba1d0fbfc36cd368b855c5afd9f02b8ffb24129114ad051b2
+ARG GLIB_SHA256=af229e1de191d66aebcdb03c7493c724fd4d0a6628b1ca4ea1f35739259b311d
 RUN \
   wget $WGET_OPTS -O glib.tar.xz "$GLIB_URL" && \
   echo "$GLIB_SHA256  glib.tar.xz" | sha256sum --status -c - && \


### PR DESCRIPTION
[NEWS](https://gitlab.gnome.org/GNOME/glib/-/blob/main/NEWS?ref_type=heads)  
