### PR TITLE
shio: Bump harfbuzz from 11.4.1 to 11.4.2

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -158,9 +158,9 @@ RUN \
 # bump: harfbuzz /LIBHARFBUZZ_VERSION=([\d.]+)/ https://github.com/harfbuzz/harfbuzz.git|*
 # bump: harfbuzz after cd build && ./hashupdate Dockerfile LIBHARFBUZZ $LATEST
 # bump: harfbuzz link "NEWS" https://github.com/harfbuzz/harfbuzz/blob/main/NEWS
-ARG LIBHARFBUZZ_VERSION=11.4.1
+ARG LIBHARFBUZZ_VERSION=11.4.2
 ARG LIBHARFBUZZ_URL="https://github.com/harfbuzz/harfbuzz/releases/download/$LIBHARFBUZZ_VERSION/harfbuzz-$LIBHARFBUZZ_VERSION.tar.xz"
-ARG LIBHARFBUZZ_SHA256=7aafab93115eb56cdc9a931ab7d19ff60d7f2937b599d140f17236f374e32698
+ARG LIBHARFBUZZ_SHA256=49ff7bd4a506486057f2918ecc856a249e3972f27ea49e3d2aa0f2afb59a57dd
 RUN \
   wget $WGET_OPTS -O harfbuzz.tar.xz "$LIBHARFBUZZ_URL" && \
   echo "$LIBHARFBUZZ_SHA256  harfbuzz.tar.xz" | sha256sum --status -c - && \


### PR DESCRIPTION
[NEWS](https://github.com/harfbuzz/harfbuzz/blob/main/NEWS)  
