### PR TITLE
shio: Bump svtav1 from 3.1.0 to 3.1.1

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -726,9 +726,9 @@ RUN \
 # bump: svtav1 /SVTAV1_VERSION=([\d.]+)/ https://gitlab.com/AOMediaCodec/SVT-AV1.git|*
 # bump: svtav1 after cd build && ./hashupdate Dockerfile SVTAV1 $LATEST
 # bump: svtav1 link "Release notes" https://gitlab.com/AOMediaCodec/SVT-AV1/-/releases/v$LATEST
-ARG SVTAV1_VERSION=3.1.0
+ARG SVTAV1_VERSION=3.1.1
 ARG SVTAV1_URL="https://gitlab.com/AOMediaCodec/SVT-AV1/-/archive/v$SVTAV1_VERSION/SVT-AV1-v$SVTAV1_VERSION.tar.bz2"
-ARG SVTAV1_SHA256=8231b63ea6c50bae46a019908786ebfa2696e5743487270538f3c25fddfa215a
+ARG SVTAV1_SHA256=a91a3a095cc3146697c6e46155f095492f177d95585e90fc87a5df1ee41869e2
 RUN \
   wget $WGET_OPTS -O svtav1.tar.bz2 "$SVTAV1_URL" && \
   echo "$SVTAV1_SHA256  svtav1.tar.bz2" | sha256sum -c - && \


### PR DESCRIPTION
[Release notes](https://gitlab.com/AOMediaCodec/SVT-AV1/-/releases/v3.1.1)  
