### PR TITLE
shio: Bump librtmp from 6f6bb1353fc84f4cc37138baa99f586750028a01 to 138fdb258d9fc26f1843fd1b891180416c9dc575

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -588,7 +588,7 @@ RUN \
 # bump: librtmp after cd build && ./hashupdate Dockerfile LIBRTMP $LATEST
 # bump: librtmp link "Commit diff $CURRENT..$LATEST" https://git.ffmpeg.org/gitweb/rtmpdump.git/commitdiff/$LATEST?ds=sidebyside
 ARG LIBRTMP_URL="https://git.ffmpeg.org/rtmpdump.git"
-ARG LIBRTMP_COMMIT=6f6bb1353fc84f4cc37138baa99f586750028a01
+ARG LIBRTMP_COMMIT=138fdb258d9fc26f1843fd1b891180416c9dc575
 RUN \
   git clone "$LIBRTMP_URL" && cd rtmpdump && \
   git checkout --recurse-submodules $LIBRTMP_COMMIT && \


### PR DESCRIPTION
[Commit diff 6f6bb1353fc84f4cc37138baa99f586750028a01..138fdb258d9fc26f1843fd1b891180416c9dc575](https://git.ffmpeg.org/gitweb/rtmpdump.git/commitdiff/138fdb258d9fc26f1843fd1b891180416c9dc575?ds=sidebyside)  
