### PR TITLE
shio: Bump alpine from 3.20.8 to 3.23.2

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,7 +2,7 @@
 
 # bump: alpine /ALPINE_VERSION=docker.io\/library\/alpine:([\d.]+)/ docker:alpine|^3
 # bump: alpine link "Release notes" https://alpinelinux.org/posts/Alpine-$LATEST-released.html
-ARG ALPINE_VERSION=docker.io/library/alpine:3.20.8
+ARG ALPINE_VERSION=docker.io/library/alpine:3.23.2
 FROM $ALPINE_VERSION AS build
 
 # Alpine Package Keeper options


### PR DESCRIPTION
[Release notes](https://alpinelinux.org/posts/Alpine-3.23.2-released.html)  
