### PR TITLE
shio: Bump glib from 2.87.0 to 2.87.1

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -142,9 +142,9 @@ RUN sed -i 's/-lvmaf /-lvmaf -lstdc++ /' /usr/local/lib/pkgconfig/libvmaf.pc
 # bump: glib /GLIB_VERSION=([\d.]+)/ https://gitlab.gnome.org/GNOME/glib.git|^2
 # bump: glib after cd build && ./hashupdate Dockerfile GLIB $LATEST
 # bump: glib link "NEWS" https://gitlab.gnome.org/GNOME/glib/-/blob/main/NEWS?ref_type=heads
-ARG GLIB_VERSION=2.87.0
+ARG GLIB_VERSION=2.87.1
 ARG GLIB_URL="https://download.gnome.org/sources/glib/2.87/glib-$GLIB_VERSION.tar.xz"
-ARG GLIB_SHA256=926cf73d8eb90ea341cc2d6fc7b258901e1a086a3808b166b4476d69a98b2401
+ARG GLIB_SHA256=fc2ce0f948ee163f8adc5bdde2f38612b8a3f270022aa1b0d087cb9f1f0ac5c2
 RUN \
   wget $WGET_OPTS -O glib.tar.xz "$GLIB_URL" && \
   echo "$GLIB_SHA256  glib.tar.xz" | sha256sum --status -c - && \


### PR DESCRIPTION
[NEWS](https://gitlab.gnome.org/GNOME/glib/-/blob/main/NEWS?ref_type=heads)  
