### PR TITLE
shio: Bump opus from 1.6 to 1.6.1

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -528,9 +528,9 @@ RUN \
 # bump: opus after cd build && ./hashupdate Dockerfile OPUS $LATEST
 # bump: opus link "Release notes" https://github.com/xiph/opus/releases/tag/v$LATEST
 # bump: opus link "Source diff $CURRENT..$LATEST" https://github.com/xiph/opus/compare/v$CURRENT..v$LATEST
-ARG OPUS_VERSION=1.6
+ARG OPUS_VERSION=1.6.1
 ARG OPUS_URL="https://downloads.xiph.org/releases/opus/opus-$OPUS_VERSION.tar.gz"
-ARG OPUS_SHA256=b7637334527201fdfd6dd6a02e67aceffb0e5e60155bbd89175647a80301c92c
+ARG OPUS_SHA256=6ffcb593207be92584df15b32466ed64bbec99109f007c82205f0194572411a1
 RUN \
   wget $WGET_OPTS -O opus.tar.gz "$OPUS_URL" && \
   echo "$OPUS_SHA256  opus.tar.gz" | sha256sum -c - && \


### PR DESCRIPTION
[Release notes](https://github.com/xiph/opus/releases/tag/v1.6.1)  
[Source diff 1.6..1.6.1](https://github.com/xiph/opus/compare/v1.6..v1.6.1)  
