### PR TITLE
shio: Bump libvpx from 1.15.2 to 1.16.0

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -854,9 +854,9 @@ RUN \
 # bump: libvpx after cd build && ./hashupdate Dockerfile VPX $LATEST
 # bump: libvpx link "CHANGELOG" https://github.com/webmproject/libvpx/blob/master/CHANGELOG
 # bump: libvpx link "Source diff $CURRENT..$LATEST" https://github.com/webmproject/libvpx/compare/v$CURRENT..v$LATEST
-ARG VPX_VERSION=1.15.2
+ARG VPX_VERSION=1.16.0
 ARG VPX_URL="https://github.com/webmproject/libvpx/archive/v$VPX_VERSION.tar.gz"
-ARG VPX_SHA256=26fcd3db88045dee380e581862a6ef106f49b74b6396ee95c2993a260b4636aa
+ARG VPX_SHA256=7a479a3c66b9f5d5542a4c6a1b7d3768a983b1e5c14c60a9396edc9b649e015c
 RUN \
   wget $WGET_OPTS -O libvpx.tar.gz "$VPX_URL" && \
   echo "$VPX_SHA256  libvpx.tar.gz" | sha256sum -c - && \


### PR DESCRIPTION
[CHANGELOG](https://github.com/webmproject/libvpx/blob/master/CHANGELOG)  
[Source diff 1.15.2..1.16.0](https://github.com/webmproject/libvpx/compare/v1.15.2..v1.16.0)  
