### PR TITLE
shio: Bump libmysofa from 1.3.3 to 1.3.4

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -469,9 +469,9 @@ RUN \
 # bump: libmysofa after cd build && ./hashupdate Dockerfile LIBMYSOFA $LATEST
 # bump: libmysofa link "Release" https://github.com/hoene/libmysofa/releases/tag/v$LATEST
 # bump: libmysofa link "Source diff $CURRENT..$LATEST" https://github.com/hoene/libmysofa/compare/v$CURRENT..v$LATEST
-ARG LIBMYSOFA_VERSION=1.3.3
+ARG LIBMYSOFA_VERSION=1.3.4
 ARG LIBMYSOFA_URL="https://github.com/hoene/libmysofa/archive/refs/tags/v$LIBMYSOFA_VERSION.tar.gz"
-ARG LIBMYSOFA_SHA256=a15f7236a2b492f8d8da69f6c71b5bde1ef1bac0ef428b94dfca1cabcb24c84f
+ARG LIBMYSOFA_SHA256=64c661f75ef39edf68bfc3a28403d2b5a0bd251d0b9f5d021ed6f7917867fb37
 RUN \
   wget $WGET_OPTS -O libmysofa.tar.gz "$LIBMYSOFA_URL" && \
   echo "$LIBMYSOFA_SHA256  libmysofa.tar.gz" | sha256sum -c - && \


### PR DESCRIPTION
[Release](https://github.com/hoene/libmysofa/releases/tag/v1.3.4)  
[Source diff 1.3.3..1.3.4](https://github.com/hoene/libmysofa/compare/v1.3.3..v1.3.4)  
