### PR TITLE
shio: Bump libgme from 184dac64cd556f435c309bb83ed4a31fe14e1cc5 to bc314435c21269628613af24ec358e25efc13e5f

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -367,7 +367,7 @@ RUN \
 # bump: libgme after cd build && ./hashupdate Dockerfile LIBGME $LATEST
 # bump: libgme link "Source diff $CURRENT..$LATEST" https://github.com/libgme/game-music-emu/compare/$CURRENT..v$LATEST
 ARG LIBGME_URL="https://github.com/libgme/game-music-emu.git"
-ARG LIBGME_COMMIT=184dac64cd556f435c309bb83ed4a31fe14e1cc5
+ARG LIBGME_COMMIT=bc314435c21269628613af24ec358e25efc13e5f
 RUN \
   git clone "$LIBGME_URL" && \
   cd game-music-emu && git checkout --recurse-submodules $LIBGME_COMMIT && \


### PR DESCRIPTION
[Source diff 184dac64cd556f435c309bb83ed4a31fe14e1cc5..bc314435c21269628613af24ec358e25efc13e5f](https://github.com/libgme/game-music-emu/compare/184dac64cd556f435c309bb83ed4a31fe14e1cc5..vbc314435c21269628613af24ec358e25efc13e5f)  
