### PR TITLE
shio: Bump libssh from 0.11.3 to 0.12.0

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -676,9 +676,9 @@ RUN \
 # bump: libssh after cd build && ./hashupdate Dockerfile LIBSSH $LATEST
 # bump: libssh link "Source diff $CURRENT..$LATEST" https://gitlab.com/libssh/libssh-mirror/-/compare/libssh-$CURRENT...libssh-$LATEST
 # bump: libssh link "Release notes" https://gitlab.com/libssh/libssh-mirror/-/tags/libssh-$LATEST
-ARG LIBSSH_VERSION=0.11.3
+ARG LIBSSH_VERSION=0.12.0
 ARG LIBSSH_URL="https://gitlab.com/libssh/libssh-mirror/-/archive/libssh-$LIBSSH_VERSION/libssh-mirror-libssh-$LIBSSH_VERSION.tar.gz"
-ARG LIBSSH_SHA256=16f4a54ee1e2d115931204fd45b87589dd8852dbfe48901c5c2dbc0b4b71da9a
+ARG LIBSSH_SHA256=dea4d0fca445522b1e40e02461f79b54a39f4d7e6814d616a5714eb0b64c3e2e
 # LIBSSH_STATIC=1 is REQUIRED to link statically against libssh.a so add to pkg-config file
 RUN \
   wget $WGET_OPTS -O libssh.tar.gz "$LIBSSH_URL" && \


### PR DESCRIPTION
[Source diff 0.11.3..0.12.0](https://gitlab.com/libssh/libssh-mirror/-/compare/libssh-0.11.3...libssh-0.12.0)  
[Release notes](https://gitlab.com/libssh/libssh-mirror/-/tags/libssh-0.12.0)  
