### PR TITLE
shio: Bump harfbuzz from 12.3.2 to 13.0.1

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -158,9 +158,9 @@ RUN \
 # bump: harfbuzz /LIBHARFBUZZ_VERSION=([\d.]+)/ https://github.com/harfbuzz/harfbuzz.git|*
 # bump: harfbuzz after cd build && ./hashupdate Dockerfile LIBHARFBUZZ $LATEST
 # bump: harfbuzz link "NEWS" https://github.com/harfbuzz/harfbuzz/blob/main/NEWS
-ARG LIBHARFBUZZ_VERSION=12.3.2
+ARG LIBHARFBUZZ_VERSION=13.0.1
 ARG LIBHARFBUZZ_URL="https://github.com/harfbuzz/harfbuzz/releases/download/$LIBHARFBUZZ_VERSION/harfbuzz-$LIBHARFBUZZ_VERSION.tar.xz"
-ARG LIBHARFBUZZ_SHA256=6f6db164359a2da5a84ef826615b448b33e6306067ad829d85d5b0bf936f1bb8
+ARG LIBHARFBUZZ_SHA256=3553d943401c34ab9b8c75f35cdb8452ca660233b0e9d4a22395ce5245484bd7
 RUN \
   wget $WGET_OPTS -O harfbuzz.tar.xz "$LIBHARFBUZZ_URL" && \
   echo "$LIBHARFBUZZ_SHA256  harfbuzz.tar.xz" | sha256sum --status -c - && \


### PR DESCRIPTION
[NEWS](https://github.com/harfbuzz/harfbuzz/blob/main/NEWS)  
