### PR TITLE
shio: Bump harfbuzz from 12.3.2 to 13.1.0

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -158,9 +158,9 @@ RUN \
 # bump: harfbuzz /LIBHARFBUZZ_VERSION=([\d.]+)/ https://github.com/harfbuzz/harfbuzz.git|*
 # bump: harfbuzz after cd build && ./hashupdate Dockerfile LIBHARFBUZZ $LATEST
 # bump: harfbuzz link "NEWS" https://github.com/harfbuzz/harfbuzz/blob/main/NEWS
-ARG LIBHARFBUZZ_VERSION=12.3.2
+ARG LIBHARFBUZZ_VERSION=13.1.0
 ARG LIBHARFBUZZ_URL="https://github.com/harfbuzz/harfbuzz/releases/download/$LIBHARFBUZZ_VERSION/harfbuzz-$LIBHARFBUZZ_VERSION.tar.xz"
-ARG LIBHARFBUZZ_SHA256=6f6db164359a2da5a84ef826615b448b33e6306067ad829d85d5b0bf936f1bb8
+ARG LIBHARFBUZZ_SHA256=a9959a0db77554d266803e1e524249ed4504695fef63524aebca749ac6260a7f
 RUN \
   wget $WGET_OPTS -O harfbuzz.tar.xz "$LIBHARFBUZZ_URL" && \
   echo "$LIBHARFBUZZ_SHA256  harfbuzz.tar.xz" | sha256sum --status -c - && \


### PR DESCRIPTION
[NEWS](https://github.com/harfbuzz/harfbuzz/blob/main/NEWS)  
