### PR TITLE
shio: Bump pango from 1.56.4 to 1.57.1

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -194,9 +194,9 @@ RUN \
 # bump: pango /PANGO_VERSION=([\d.]+)/ https://github.com/GNOME/pango.git|/\d+\.\d+\.\d+/|*
 # bump: pango after cd build && ./hashupdate Dockerfile PANGO $LATEST
 # bump: pango link "NEWS" https://gitlab.gnome.org/GNOME/pango/-/blob/main/NEWS?ref_type=heads
-ARG PANGO_VERSION=1.56.4
+ARG PANGO_VERSION=1.57.1
 ARG PANGO_URL="https://download.gnome.org/sources/pango/1.56/pango-$PANGO_VERSION.tar.xz"
-ARG PANGO_SHA256=17065e2fcc5f5a5bdbffc884c956bfc7c451a96e8c4fb2f8ad837c6413cb5a01
+ARG PANGO_SHA256=1b99284bfc6859dc384b7c81a29eda1eb815005952a1a78f6d7b21ab30726286
 # TODO: add -Dbuild-testsuite=false when in stable release
 # TODO: -Ddefault_library=both currently to not fail building tests
 RUN \


### PR DESCRIPTION
[NEWS](https://gitlab.gnome.org/GNOME/pango/-/blob/main/NEWS?ref_type=heads)  
