### PR TITLE
shio: Bump libgme from 60e0a2796a715b7443890d3d6c95d357b84d7726 to af9bc2ed382f796f407327e1a640767e9b3f08a9

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -367,7 +367,7 @@ RUN \
 # bump: libgme after cd build && ./hashupdate Dockerfile LIBGME $LATEST
 # bump: libgme link "Source diff $CURRENT..$LATEST" https://github.com/libgme/game-music-emu/compare/$CURRENT..v$LATEST
 ARG LIBGME_URL="https://github.com/libgme/game-music-emu.git"
-ARG LIBGME_COMMIT=60e0a2796a715b7443890d3d6c95d357b84d7726
+ARG LIBGME_COMMIT=af9bc2ed382f796f407327e1a640767e9b3f08a9
 RUN \
   git clone "$LIBGME_URL" && \
   cd game-music-emu && git checkout --recurse-submodules $LIBGME_COMMIT && \


### PR DESCRIPTION
[Source diff 60e0a2796a715b7443890d3d6c95d357b84d7726..af9bc2ed382f796f407327e1a640767e9b3f08a9](https://github.com/libgme/game-music-emu/compare/60e0a2796a715b7443890d3d6c95d357b84d7726..vaf9bc2ed382f796f407327e1a640767e9b3f08a9)  
