### PR TITLE
shio: Bump vmaf from 3.0.0 to 3.1.0

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -119,9 +119,9 @@ RUN \
 # bump: vmaf after cd build && ./hashupdate Dockerfile VMAF $LATEST
 # bump: vmaf link "Release" https://github.com/Netflix/vmaf/releases/tag/v$LATEST
 # bump: vmaf link "Source diff $CURRENT..$LATEST" https://github.com/Netflix/vmaf/compare/v$CURRENT..v$LATEST
-ARG VMAF_VERSION=3.0.0
+ARG VMAF_VERSION=3.1.0
 ARG VMAF_URL="https://github.com/Netflix/vmaf/archive/refs/tags/v$VMAF_VERSION.tar.gz"
-ARG VMAF_SHA256=7178c4833639e6b989ecae73131d02f70735fdb3fc2c7d84bc36c9c3461d93b1
+ARG VMAF_SHA256=80090e29d7fd0db472ddc663513f5be89bc936815e62b767e630c1d627279fe2
 RUN \
   wget $WGET_OPTS -O vmaf.tar.gz "$VMAF_URL" && \
   echo "$VMAF_SHA256  vmaf.tar.gz" | sha256sum -c - && \


### PR DESCRIPTION
[Release](https://github.com/Netflix/vmaf/releases/tag/v3.1.0)  
[Source diff 3.0.0..3.1.0](https://github.com/Netflix/vmaf/compare/v3.0.0..v3.1.0)  
