### PR TITLE
shio: Bump lcms2 from 2.19 to 2.19.1

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -452,9 +452,9 @@ RUN \
 # bump: lcms2 /LCMS2_VERSION=([\d.]+)/ https://github.com/mm2/Little-CMS.git|^2
 # bump: lcms2 after cd build && ./hashupdate Dockerfile LCMS2 $LATEST
 # bump: lcms2 link "Release" https://github.com/mm2/Little-CMS/releases/tag/lcms$LATEST
-ARG LCMS2_VERSION=2.19
+ARG LCMS2_VERSION=2.19.1
 ARG LCMS2_URL="https://github.com/mm2/Little-CMS/releases/download/lcms$LCMS2_VERSION/lcms2-$LCMS2_VERSION.tar.gz"
-ARG LCMS2_SHA256=49e7e134e4299733dd0eda434fa468997a28ab3d33fa397c642b03644f552216
+ARG LCMS2_SHA256=bfc54f7bab59fbc921012014a8032e4cba4abd46db47d46b76416a8c0b2815c8
 RUN \
   wget $WGET_OPTS -O lcms2.tar.gz "$LCMS2_URL" && \
   echo "$LCMS2_SHA256  lcms2.tar.gz" | sha256sum -c - && \


### PR DESCRIPTION
[Release](https://github.com/mm2/Little-CMS/releases/tag/lcms2.19.1)  
