### PR TITLE
shio: Bump glib from 2.88.1 to 2.89.1

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -142,9 +142,9 @@ RUN sed -i 's/-lvmaf /-lvmaf -lstdc++ /' /usr/local/lib/pkgconfig/libvmaf.pc
 # bump: glib /GLIB_VERSION=([\d.]+)/ https://gitlab.gnome.org/GNOME/glib.git|^2
 # bump: glib after cd build && ./hashupdate Dockerfile GLIB $LATEST
 # bump: glib link "NEWS" https://gitlab.gnome.org/GNOME/glib/-/blob/main/NEWS?ref_type=heads
-ARG GLIB_VERSION=2.88.1
+ARG GLIB_VERSION=2.89.1
 ARG GLIB_URL="https://download.gnome.org/sources/glib/2.88/glib-$GLIB_VERSION.tar.xz"
-ARG GLIB_SHA256=51ab804c56f6eab3e5045c774d1290ac5e4c923d4f9a3d8e33123bee45c1840e
+ARG GLIB_SHA256=e3f6df9d79046312dc18023269c502836918b765421013e8f922b577d6b5dc3f
 RUN \
   wget $WGET_OPTS -O glib.tar.xz "$GLIB_URL" && \
   echo "$GLIB_SHA256  glib.tar.xz" | sha256sum --status -c - && \


### PR DESCRIPTION
[NEWS](https://gitlab.gnome.org/GNOME/glib/-/blob/main/NEWS?ref_type=heads)  
