### PR TITLE
shio: Bump libva from 2.23.0 to 2.24.0

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1085,9 +1085,9 @@ RUN \
 # bump: libva /LIBVA_VERSION=([\d.]+)/ https://github.com/intel/libva.git|^2
 # bump: libva after cd build && ./hashupdate Dockerfile LIBVA $LATEST
 # bump: libva link "Changelog" https://github.com/intel/libva/blob/master/NEWS
-ARG LIBVA_VERSION=2.23.0
+ARG LIBVA_VERSION=2.24.0
 ARG LIBVA_URL="https://github.com/intel/libva/archive/refs/tags/${LIBVA_VERSION}.tar.gz"
-ARG LIBVA_SHA256=b10aceb30e93ddf13b2030eb70079574ba437be9b3b76065caf28a72c07e23e7
+ARG LIBVA_SHA256=d5558cd419c8d46bdc958064cb97f963d1ea793866414c025906ec15033512ed
 RUN \
   wget $WGET_OPTS -O libva.tar.gz "$LIBVA_URL" && \
   echo "$LIBVA_SHA256  libva.tar.gz" | sha256sum -c - && \


### PR DESCRIPTION
[Changelog](https://github.com/intel/libva/blob/master/NEWS)  
